### PR TITLE
feat: routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react-datepicker": "^7.5.0",
         "react-daum-postcode": "^3.1.3",
         "react-dom": "^18.3.1",
+        "react-router": "^7.0.2",
         "zustand": "^5.0.2"
       },
       "devDependencies": {
@@ -842,6 +843,12 @@
       "dependencies": {
         "@babel/types": "^7.20.7"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.6",
@@ -1696,6 +1703,15 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2943,7 +2959,8 @@
     "node_modules/hoist-non-react-statics": {
       "version": "2.5.5",
       "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
+      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -3914,6 +3931,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
       "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+      "license": "MIT",
       "dependencies": {
         "isarray": "0.0.1"
       }
@@ -3921,7 +3939,8 @@
     "node_modules/path-to-regexp/node_modules/isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4279,20 +4298,27 @@
       }
     },
     "node_modules/react-router": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
-      "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.0.2.tgz",
+      "integrity": "sha512-m5AcPfTRUcjwmhBzOJGEl6Y7+Crqyju0+TgTQxoS4SO+BkWbhOrcfZNq6wSWdl2BBbJbsAoBUb8ZacOFT+/JlA==",
+      "license": "MIT",
       "dependencies": {
-        "history": "^4.7.2",
-        "hoist-non-react-statics": "^2.5.0",
-        "invariant": "^2.2.4",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.1",
-        "warning": "^4.0.1"
+        "@types/cookie": "^0.6.0",
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0",
+        "turbo-stream": "2.4.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
@@ -4305,6 +4331,24 @@
         "loose-envify": "^1.3.1",
         "prop-types": "^15.6.1",
         "react-router": "^4.3.1",
+        "warning": "^4.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=15"
+      }
+    },
+    "node_modules/react-router-dom/node_modules/react-router": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
+      "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
+      "license": "MIT",
+      "dependencies": {
+        "history": "^4.7.2",
+        "hoist-non-react-statics": "^2.5.0",
+        "invariant": "^2.2.4",
+        "loose-envify": "^1.3.1",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.1",
         "warning": "^4.0.1"
       },
       "peerDependencies": {
@@ -4526,6 +4570,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -5033,6 +5083,12 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true
+    },
+    "node_modules/turbo-stream": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
+      "license": "ISC"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -6100,6 +6156,11 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
+    },
     "@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -6669,6 +6730,11 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA=="
     },
     "cross-spawn": {
       "version": "7.0.6",
@@ -8467,17 +8533,14 @@
       "dev": true
     },
     "react-router": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
-      "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.0.2.tgz",
+      "integrity": "sha512-m5AcPfTRUcjwmhBzOJGEl6Y7+Crqyju0+TgTQxoS4SO+BkWbhOrcfZNq6wSWdl2BBbJbsAoBUb8ZacOFT+/JlA==",
       "requires": {
-        "history": "^4.7.2",
-        "hoist-non-react-statics": "^2.5.0",
-        "invariant": "^2.2.4",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.1",
-        "warning": "^4.0.1"
+        "@types/cookie": "^0.6.0",
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0",
+        "turbo-stream": "2.4.0"
       }
     },
     "react-router-dom": {
@@ -8491,6 +8554,22 @@
         "prop-types": "^15.6.1",
         "react-router": "^4.3.1",
         "warning": "^4.0.1"
+      },
+      "dependencies": {
+        "react-router": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
+          "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
+          "requires": {
+            "history": "^4.7.2",
+            "hoist-non-react-statics": "^2.5.0",
+            "invariant": "^2.2.4",
+            "loose-envify": "^1.3.1",
+            "path-to-regexp": "^1.7.0",
+            "prop-types": "^15.6.1",
+            "warning": "^4.0.1"
+          }
+        }
       }
     },
     "read-cache": {
@@ -8642,6 +8721,11 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true
+    },
+    "set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
     },
     "set-function-length": {
       "version": "1.2.2",
@@ -9005,6 +9089,11 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true
+    },
+    "turbo-stream": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-datepicker": "^7.5.0",
     "react-daum-postcode": "^3.1.3",
     "react-dom": "^18.3.1",
+    "react-router": "^7.0.2",
     "zustand": "^5.0.2"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,9 +20,9 @@ function App() {
       {/* 랜딩페이지? */}
       <Route path="/start" element={<SplashPage />} />
       {/* 만들기 페이지 */}
-      <Route path="/edit1" element={< CreateInvitationPage1 />} />
-      <Route path="/edit2" element={< CreateInvitationPage2 />} />
-      <Route path="/edit3" element={< CreateInvitationPage3 />} />
+      <Route path="/create/1" element={< CreateInvitationPage1 />} />
+      <Route path="/create/2" element={< CreateInvitationPage2 />} />
+      <Route path="/create/3" element={< CreateInvitationPage3 />} />
       {/* TODO:Preview page */}
     </Routes>
   )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,31 @@
 import './App.css';
 import React from 'react';
+import HomePage from './pages/HomePage';
+import LoginPage from './pages/LoginPage';
+import SignUpPage from './pages/SignUpPage';
+import SplashPage from './pages/SplashPage';
+import { Route, Routes } from 'react-router';
+import CreateInvitationPage1 from './pages/CreateInvitationPage1';
+import CreateInvitationPage2 from './pages/CreateInvitationPage2';
+import CreateInvitationPage3 from './pages/CreateInvitationPage3';
 
 function App() {
-  return <></>;
+  return (
+    <Routes>
+      {/* 홈페이지 */}
+      <Route path="/" element={<HomePage />} />
+      {/* 로그인/회원가입 */}
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/signup" element={<SignUpPage />} />
+      {/* 랜딩페이지? */}
+      <Route path="/start" element={<SplashPage />} />
+      {/* 만들기 페이지 */}
+      <Route path="/edit1" element={< CreateInvitationPage1 />} />
+      <Route path="/edit2" element={< CreateInvitationPage2 />} />
+      <Route path="/edit3" element={< CreateInvitationPage3 />} />
+      {/* TODO:Preview page */}
+    </Routes>
+  )
 }
 
 export default App;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './styles/global.css';
 import App from './App.tsx';
+import { BrowserRouter } from 'react-router';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 );

--- a/src/pages/CreateInvitationPage1.tsx
+++ b/src/pages/CreateInvitationPage1.tsx
@@ -4,11 +4,13 @@ import HeaderButton from '../components/common/Header/HeaderButton';
 import InvitationTitleInput from '../components/common/CreateInvitation/InvitationTitleInput';
 import WeddingDateInput from '../components/form/WeddingDateInput/WeddingDateInput';
 import { useInvitationStore } from '../store/useInvitaionStore';
+import { useNavigate } from 'react-router';
 
-const CreateInvitationPage: React.FC = () => {
+const CreateInvitationPage1: React.FC = () => {
   const { title, setTitle } = useInvitationStore();
+  const navigate = useNavigate()
 
-  const handleCancel = () => console.log('취소 버튼 클릭');
+  const handleCancel = () => navigate('/home');
   const handleSave = () => console.log('저장 버튼 클릭, 제목: ', title);
 
   return (
@@ -45,4 +47,4 @@ const CreateInvitationPage: React.FC = () => {
   );
 };
 
-export default CreateInvitationPage;
+export default CreateInvitationPage1;

--- a/src/pages/CreateInvitationPage2.tsx
+++ b/src/pages/CreateInvitationPage2.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import PageLayout from '../components/layout/PageLayout';
+import HeaderButton from '../components/common/Header/HeaderButton';
+import InvitationTitleInput from '../components/common/CreateInvitation/InvitationTitleInput';
+import WeddingDateInput from '../components/form/WeddingDateInput/WeddingDateInput';
+import { useInvitationStore } from '../store/useInvitaionStore';
+
+const CreateInvitationPage2: React.FC = () => {
+  const { title, setTitle } = useInvitationStore();
+
+  const handleCancel = () => console.log('취소 버튼 클릭');
+  const handleSave = () => console.log('저장 버튼 클릭, 제목: ', title);
+
+  return (
+    <PageLayout
+      title="새로운 청첩장"
+      leftButton={
+        <HeaderButton
+          onClick={handleCancel}
+          className="hover:text-pink-400 active:text-pink-600"
+        >
+          취소
+        </HeaderButton>
+      }
+      rightButton={
+        <HeaderButton
+          onClick={handleSave}
+          className="hover:text-pink-400 active:text-pink-600"
+        >
+          저장
+        </HeaderButton>
+      }
+    >
+      <div>
+        {/* 청첩장 제목 입력 */}
+        <InvitationTitleInput
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+
+        {/* 웨딩 일시 입력 */}
+        <WeddingDateInput />
+      </div>
+    </PageLayout>
+  );
+};
+
+export default CreateInvitationPage2;

--- a/src/pages/CreateInvitationPage3.tsx
+++ b/src/pages/CreateInvitationPage3.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import PageLayout from '../components/layout/PageLayout';
+import HeaderButton from '../components/common/Header/HeaderButton';
+import InvitationTitleInput from '../components/common/CreateInvitation/InvitationTitleInput';
+import WeddingDateInput from '../components/form/WeddingDateInput/WeddingDateInput';
+import { useInvitationStore } from '../store/useInvitaionStore';
+
+const CreateInvitationPage3: React.FC = () => {
+  const { title, setTitle } = useInvitationStore();
+
+  const handleCancel = () => console.log('취소 버튼 클릭');
+  const handleSave = () => console.log('저장 버튼 클릭, 제목: ', title);
+
+  return (
+    <PageLayout
+      title="새로운 청첩장"
+      leftButton={
+        <HeaderButton
+          onClick={handleCancel}
+          className="hover:text-pink-400 active:text-pink-600"
+        >
+          취소
+        </HeaderButton>
+      }
+      rightButton={
+        <HeaderButton
+          onClick={handleSave}
+          className="hover:text-pink-400 active:text-pink-600"
+        >
+          저장
+        </HeaderButton>
+      }
+    >
+      <div>
+        {/* 청첩장 제목 입력 */}
+        <InvitationTitleInput
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+
+        {/* 웨딩 일시 입력 */}
+        <WeddingDateInput />
+      </div>
+    </PageLayout>
+  );
+};
+
+export default CreateInvitationPage3;

--- a/src/pages/SplashPage.tsx
+++ b/src/pages/SplashPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-const StartPage = () => {
+const SplashPage = () => {
   return <div>StartPage</div>;
 };
 
-export default StartPage;
+export default SplashPage;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -27,7 +27,7 @@
   }
 
   .content {
-    @apply p-4 bg-gray-200 h-screen;
+    @apply p-4 bg-gray-200 min-h-screen;
     padding-top: var(--header-height);
   }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈 (선택)

## 📝 작업 내용
App.tsx 에는 라우팅을 관리해주고 아직 페이지들 이름이랑 해당 페이지들 다 구현이 안되서 만들기 페이지는 하나로만 연결 했습니다.
CreateInvitationPage1 에서 navigating 사용하는 예시가 있는데 해당 훅 사용하셔도 되고 아니면
https://reactrouter.com/start/framework/navigating#usenavigate 여기서 골라서 사용하셔도 됩니다.


  `const navigate = useNavigate()`
`const handleCancel = () => navigate("/home")`
`const handleSave = () => navigate("/edit2")`

--- 현재까지 페이지

- Home --> HomePage --> /
- Start Page --> SplashPage --> /splash
- 로그인 --> LoginPage --> /login
- 회원가입 --> SignUpPage ---> /signup
- 만들기 1 --> CreateInvitationPage1(수정예정) --> /edit1(수정예정)
- 만들기 2 --> CreateInvitationPage2(수정 예정) --> /edit2(수정예정)
- 만들기 3 --> CreateInvitationPage3(수정 예정) --> /edit3(수정예정)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
