### PR TITLE
[FIX] :  갤러리 레이아웃수정

### DIFF
--- a/src/actions/invitationAction.ts
+++ b/src/actions/invitationAction.ts
@@ -48,6 +48,7 @@ export const getInvitationAction = (): InvitationDetiail => {
     attendanceTitle: '참석 여부 제목',
     attendanceContent: '참석 여부 설명',
     attendanceIsDining: true,
+    //attendance: true,
   };
 };
 

--- a/src/components/display/GallerySection/GallerySection.tsx
+++ b/src/components/display/GallerySection/GallerySection.tsx
@@ -3,12 +3,23 @@ import ChevronLeft from '@icons/Chevron_LeftIcon';
 import ChevronRight from '@icons/Chevron_RightIcon';
 import useGallaryStore from '@store/useGallaryStore';
 import { useOptionalFeatureStore } from '@store/OptionalFeature/useOptionalFeatureStore';
+import CloseIcon from '@/components/icons/CloseIcon';
+import { useLocation } from 'react-router';
+
 
 export default function GallerySection() {
-  const store = useGallaryStore();
-  const images = store.images;
-  const grid = store.grid;
+  const { images, grid } = useGallaryStore();
 
+  const [modal, setModal] = useState(false)
+  const { pathname } = useLocation()
+  const isPreview = pathname == "/create"
+  const handleModal = (index: number) => {
+    //수정페이지 pathname 확인
+    if (!isPreview) {
+      setModal(!modal)
+      setImageIndex(index)
+    }
+  }
   const [imageIndex, setImageIndex] = useState(0);
   const handlePrev = () => {
     if (imageIndex == 0) {
@@ -23,30 +34,48 @@ export default function GallerySection() {
 
   const { selectedOptionalFeatures } = useOptionalFeatureStore();
   const isMainGalleryActive = selectedOptionalFeatures.gallery;
-
   return (
-    <div className="bg-white w-full h-fit p-2">
+    <div className="bg-white w-full h-fit">
       {isMainGalleryActive && images ? (
         grid ? (
-          <section className="grid grid-cols-3 gap-2">
+          <section className={`relative w-full grid grid-cols-3  ${isPreview ? "gap-3 " : "gap-y-3 px-2"}  justify-items-center items-center`}>
             {images.map((value, index) => {
               return (
-                <div key={index}>
-                  <img src={value} alt="" className="w-24" />
-                </div>
+                <button key={index} className="rounded-md w-24 h-32" onClick={() => handleModal(index)}>
+                  <img key={index} src={value} alt="" className="rounded-md size-full object-center" />
+                </button>
               );
             })}
+            {
+              modal && <button className='absolute top-2 right-2 z-10' onClick={() => handleModal(0)}>
+                <CloseIcon className='text-white hover:bg-gray-400 rounded-full' />
+              </button>
+            }
+            {
+              modal &&
+              <div className="absolute flex flex-row gap-2  justify-center items-center bg-black/70 size-full">
+                <button onClick={handlePrev} className='bg-white h-6 rounded-full flex items-center justify-center'>
+                  <ChevronLeft />
+                </button>
+                <img src={images[imageIndex]} alt="gallery-image" className='w-72 rounded-md' />
+                <button onClick={handleNext} className='bg-white h-6 rounded-full flex items-center justify-center'>
+                  <ChevronRight />
+                </button>
+              </div>
+            }
           </section>
         ) : (
-          <section className="flex flex-col w-full h-[300px] justify-around items-center">
-            <img src={images[imageIndex]} alt="" className="w-42 h-52" />
+          <section className="flex flex-col w-full h-fit gap-2 px-3 justify-around items-center">
+            <div className="w-full h-[450px]">
+              <img src={images[imageIndex]} alt="" className='size-full rounded-md' />
+            </div>
             <div className="flex flex-row  gap-4 justify-center">
               <button onClick={handlePrev}>
-                <ChevronLeft />
+                <ChevronLeft className='' />
               </button>
               <div>{`${imageIndex + 1} / ${images.length}`}</div>
               <button onClick={handleNext}>
-                <ChevronRight />
+                <ChevronRight className='' />
               </button>
             </div>
           </section>

--- a/src/components/form/Feature/RsvpFeature/RsvpExample.tsx
+++ b/src/components/form/Feature/RsvpFeature/RsvpExample.tsx
@@ -11,9 +11,8 @@ const RsvpExample = () => {
     title: '',
     desc: '',
   });
-  const [meal, setMeal] = useState(false);
-  const [population, setPopulation] = useState(false);
-
+  // const [meal, setMeal] = useState(false);
+  // const [population, setPopulation] = useState(false);
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) => {
@@ -54,7 +53,7 @@ const RsvpExample = () => {
             placeholder="설명을 입력해주세요..."
           />
         </div>
-        <hr />
+        {/* <hr />
         <div className="flex flex-row justify-between items-center  border rounded-md p-2">
           식사여부
           <Toggle state={meal} setState={setMeal} />
@@ -62,7 +61,7 @@ const RsvpExample = () => {
         <div className="flex flex-row justify-between items-center border rounded-md p-2">
           참석 인원
           <Toggle state={population} setState={setPopulation} />
-        </div>
+        </div> */}
       </section>
     </div>
   );


### PR DESCRIPTION
## #️⃣ 연관된 이슈 (선택)

> ex) #이슈번호, #이슈번호

## 📝 작업 내용
- [x]  전반적인 레이아웃 및 object-cover반영 
- [x] 인덱스 넘어가는 에러 수정 
- [x] 결과 페이지에 그리드일시 모달 추가
- [x] 참석여부 선택사항 제거 ( 식사여부 표시, 인원표시)


|레이아웃|모달|
|-----|-----|
|<img width="459" alt="image" src="https://github.com/user-attachments/assets/f9669aed-bd25-4f3c-abcf-f5364b382029" />|<img width="531" alt="image" src="https://github.com/user-attachments/assets/ae98b999-9a0e-4b6b-ae01-d0c74b9cdb5f" />|

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
