### PR TITLE
[Feat] 포토톡 사진 다운로드 기능 & 웹 접근성 개선

### DIFF
--- a/src/components/common/PhotoTalk/PhotoTalkGallery.tsx
+++ b/src/components/common/PhotoTalk/PhotoTalkGallery.tsx
@@ -1,10 +1,8 @@
 import { useState } from 'react';
 import usePhotoTalkStore from '@store/usePhotoTalkStore';
-import ChevronLeft from '@icons/Chevron_LeftIcon';
-import ChevronRight from '@icons/Chevron_RightIcon';
 import DownloadIcon from '@/components/icons/DownloadIcon';
-import JSZip from 'jszip';
-import { saveAs } from 'file-saver';
+import { downloadSelectedImages } from '@/utils/downloadUtils';
+import PhotoTalkGalleryModal from '@/components/common/PhotoTalk/PhotoTalkGalleryModal';
 
 interface PhotoTalkGalleryProps {
   isAdmin?: boolean;
@@ -17,8 +15,6 @@ const PhotoTalkGallery = ({ isAdmin = false }: PhotoTalkGalleryProps) => {
   const [isModalOpen, setModalOpen] = useState(false);
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
 
-  const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
-
   const toggleSelectImage = (url: string) => {
     setSelectedImages((prevSelected) =>
       prevSelected.includes(url)
@@ -27,66 +23,16 @@ const PhotoTalkGallery = ({ isAdmin = false }: PhotoTalkGalleryProps) => {
     );
   };
 
-  const downloadSelectedImages = async (selectedImages: string[]) => {
-    // zip 다운
-    if (selectedImages.length >= 10) {
-      const zip = new JSZip();
-      const folder = zip.folder('phototalk-images');
-
-      await Promise.all(
-        selectedImages.map(async (url, index) => {
-          const response = await fetch(url);
-          const blob = await response.blob();
-          folder?.file(`phototalk_${index + 1}.jpg`, blob);
-        }),
-      );
-
-      const content = await zip.generateAsync({ type: 'blob' });
-      saveAs(content, 'phototalk_images.zip');
-    } else {
-      // 순차 다운
-      for (let i = 0; i < selectedImages.length; i++) {
-        const url = selectedImages[i];
-        const link = document.createElement('a');
-        link.href = url;
-        link.download = `phototalk_${i + 1}.jpg`;
-        document.body.appendChild(link);
-        link.click();
-        document.body.removeChild(link);
-
-        await delay(500);
-      }
-    }
-
-    console.log(`${selectedImages.length} images downloaded`);
-  };
-
-  const downloadCurrentImage = () => {
-    const url = images[currentImageIndex];
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `phototalk_${currentImageIndex + 1}.jpg`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
+  // 여러 장 다운로드
+  const handleDownloadSelected = async () => {
+    await downloadSelectedImages(selectedImages);
   };
 
   const openModal = (index: number) => {
     setCurrentImageIndex(index);
     setModalOpen(true);
   };
-
   const closeModal = () => setModalOpen(false);
-
-  const showNextImage = () => {
-    setCurrentImageIndex((prevIndex) => (prevIndex + 1) % images.length);
-  };
-
-  const showPreviousImage = () => {
-    setCurrentImageIndex((prevIndex) =>
-      prevIndex === 0 ? images.length - 1 : prevIndex - 1,
-    );
-  };
 
   if (images.length === 0) {
     return (
@@ -99,98 +45,58 @@ const PhotoTalkGallery = ({ isAdmin = false }: PhotoTalkGalleryProps) => {
   return (
     <div>
       {isAdmin && (
-        <div className="flex justify-end items-center px-2">
-          {/* <h2 className="text-xs text-black/50">사진을 관리할 수 있습니다.</h2> */}
+        <header className="flex justify-end items-center px-2" role="banner">
           <div className="flex-center gap-2 mb-2">
             <p className="text-gray-700 text-xs">
               {selectedImages.length} / {images.length}
             </p>
             <button
-              onClick={() => downloadSelectedImages(selectedImages)}
+              onClick={handleDownloadSelected}
               className="bg-white/80 px-2 py-1 rounded-xl active:bg-black/30 shadow-md"
               disabled={selectedImages.length === 0}
+              aria-label="선택한 이미지 다운로드"
             >
               <DownloadIcon />
             </button>
           </div>
-        </div>
+        </header>
       )}
 
-      <div className="grid grid-cols-3 gap-[2px] p-2 place-items-center">
+      <main
+        className="grid grid-cols-3 gap-[2px] p-2 place-items-center"
+        role="main"
+      >
         {images.map((url, index) => (
-          <div key={index} className="relative group">
+          <div key={index} className="relative group hover:opacity-95">
             {isAdmin && (
               <div className="absolute -top-1 left-0 p-1 rounded-sm">
                 <input
                   type="checkbox"
                   checked={selectedImages.includes(url)}
                   onChange={() => toggleSelectImage(url)}
-                  className="size-4 rounded bg-white/60 cursor-pointer z-10 border-none shadow-inner checked:bg-black focus:ring-0 focus:outline-none"
+                  className="size-4 rounded bg-white/60  cursor-pointer z-10 border-none shadow-inner checked:bg-black focus:ring-0 focus:outline-none"
+                  aria-label={`이미지 ${index + 1} 선택`}
                 />
               </div>
             )}
 
             <img
               src={url}
-              alt={`Uploaded ${index}`}
+              alt={`Uploaded image ${index + 1}`}
               className="w-full aspect-[1/1] rounded-sm object-cover cursor-pointer shadow-custom"
               onClick={() => openModal(index)}
             />
           </div>
         ))}
-      </div>
+      </main>
 
       {isModalOpen && (
-        <div
-          onClick={closeModal}
-          className="max-w-[520px] m-auto column-center fixed inset-0 z-50 bg-black bg-opacity-80"
-        >
-          <div
-            onClick={(e) => e.stopPropagation()}
-            className="relative w-[90%] aspect-[4/5] rounded-2xl overflow-hidden backdrop-blur-3xl bg-black/30 shadow-custom py-16 "
-          >
-            <div className="relative flex-center w-full h-full px-4">
-              <button
-                onClick={showPreviousImage}
-                className="absolute left-3 top-1/2 transform -translate-y-1/2 rounded-full hover:opacity-50"
-              >
-                <ChevronLeft className="size-7 text-white/70" />
-              </button>
-
-              {/* <div className="p-10"> */}
-              <img
-                src={images[currentImageIndex]}
-                alt="미리보기"
-                className="max-w-full max-h-full object-contain rounded-xl"
-              />
-              {/* </div> */}
-
-              <button
-                onClick={showNextImage}
-                className="absolute right-3 top-1/2 transform -translate-y-1/2rounded-full hover:opacity-50"
-              >
-                <ChevronRight className="size-7 text-white/70" />
-              </button>
-            </div>
-
-            {isAdmin && (
-              <footer className="absolute bottom-3 right-0 left-0 m-auto w-full gap-4 text-white/80 px-4">
-                <button
-                  className="w-1/2 py-3 text-xs rounded-xl bg-black/0 hover:bg-white/10 font-medium"
-                  onClick={() => {}}
-                >
-                  삭제
-                </button>
-                <button
-                  className="w-1/2 py-3 text-xs rounded-xl bg-black/0 hover:bg-white/10 font-medium"
-                  onClick={downloadCurrentImage}
-                >
-                  다운로드
-                </button>
-              </footer>
-            )}
-          </div>
-        </div>
+        <PhotoTalkGalleryModal
+          isAdmin={isAdmin}
+          images={images}
+          currentImageIndex={currentImageIndex}
+          closeModal={closeModal}
+        />
       )}
     </div>
   );

--- a/src/components/common/PhotoTalk/PhotoTalkGallery.tsx
+++ b/src/components/common/PhotoTalk/PhotoTalkGallery.tsx
@@ -23,6 +23,11 @@ const PhotoTalkGallery = ({ isAdmin = false }: PhotoTalkGalleryProps) => {
     );
   };
 
+  const toggleAllImages = () => {
+    const allSelected = selectedImages.length === images.length;
+    return setSelectedImages(allSelected ? [] : [...images]);
+  };
+
   // 여러 장 다운로드
   const handleDownloadSelected = async () => {
     await downloadSelectedImages(selectedImages);
@@ -45,20 +50,38 @@ const PhotoTalkGallery = ({ isAdmin = false }: PhotoTalkGalleryProps) => {
   return (
     <div>
       {isAdmin && (
-        <header className="flex justify-end items-center px-2" role="banner">
-          <div className="flex-center gap-2 mb-2">
-            <p className="text-gray-700 text-xs">
-              {selectedImages.length} / {images.length}
-            </p>
-            <button
-              onClick={handleDownloadSelected}
-              className="bg-white/80 px-2 py-1 rounded-xl active:bg-black/30 shadow-md"
-              disabled={selectedImages.length === 0}
-              aria-label="선택한 이미지 다운로드"
+        <header className="flex justify-between items-center m-2" role="banner">
+          <div className="flex-center gap-1">
+            <input
+              type="checkbox"
+              id="check-all"
+              checked={selectedImages.length === images.length}
+              onChange={toggleAllImages}
+              className="size-4 rounded bg-white border border-gray-200 cursor-pointer z-10 shadow-inner checked:bg-black focus:ring-0 focus:outline-none"
+              aria-label={`이미지 전체 선택`}
+            />
+            <label
+              htmlFor="check-all"
+              className="text-xs font-light text-black/80"
             >
-              <DownloadIcon />
-            </button>
+              모두 선택하기
+            </label>
+
+            <p className="text-xs font-light text-black/80">
+              <span>( </span>
+              <span className="font-medium">{selectedImages.length}</span>
+              <span className=""> / {images.length} ) </span>
+            </p>
           </div>
+
+          <button
+            onClick={handleDownloadSelected}
+            className="bg-white/80 px-2 py-1 rounded-xl active:bg-black/30 shadow-md"
+            disabled={selectedImages.length === 0}
+            aria-label="선택한 이미지 다운로드"
+          >
+            <DownloadIcon />
+          </button>
         </header>
       )}
 

--- a/src/components/common/PhotoTalk/PhotoTalkGalleryModal.tsx
+++ b/src/components/common/PhotoTalk/PhotoTalkGalleryModal.tsx
@@ -1,0 +1,121 @@
+import ChevronLeft from '@/components/icons/Chevron_LeftIcon';
+import ChevronRight from '@/components/icons/Chevron_RightIcon';
+import { downloadImage } from '@/utils/downloadUtils';
+import { useEffect, useRef, useState } from 'react';
+
+interface PhotoTalkGalleryModalProps {
+  isAdmin: boolean;
+  images: string[];
+  currentImageIndex: number;
+  closeModal: () => void;
+}
+
+const PhotoTalkGalleryModal = ({
+  isAdmin,
+  images,
+  currentImageIndex,
+  closeModal,
+}: PhotoTalkGalleryModalProps) => {
+  const [currentIndex, setCurrentIndex] = useState(currentImageIndex);
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setCurrentIndex(currentImageIndex);
+  }, [currentImageIndex]);
+
+  useEffect(() => {
+    modalRef.current?.focus();
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        closeModal();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [closeModal]);
+
+  const showNextImage = () => {
+    setCurrentIndex((prevIndex) => (prevIndex + 1) % images.length);
+  };
+
+  const showPreviousImage = () => {
+    setCurrentIndex((prevIndex) =>
+      prevIndex === 0 ? images.length - 1 : prevIndex - 1,
+    );
+  };
+
+  const downloadCurrentImage = () => {
+    const url = images[currentIndex];
+    downloadImage(url, currentIndex);
+  };
+
+  return (
+    <section
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="modal-title"
+      aria-describedby="modal-description"
+      onClick={closeModal}
+      ref={modalRef}
+      tabIndex={-1}
+      className="max-w-[520px] m-auto column-center fixed inset-0 z-50 bg-black bg-opacity-80 focus:ring-0 focus:border-none"
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="w-[90%] aspect-[3/4] rounded-2xl overflow-hidden backdrop-blur-3xl bg-black/30 shadow-custom py-8"
+      >
+        <header>
+          <h2 id="modal-title" className="sr-only">
+            포토톡 미리보기
+          </h2>
+        </header>
+        <div
+          className="relative flex-center w-full h-full p-10"
+          id="modal-description"
+        >
+          <button
+            onClick={showPreviousImage}
+            className="absolute left-2 top-1/2 transform -translate-y-1/2 rounded-full hover:opacity-50"
+          >
+            <ChevronLeft className="size-8 text-white/80" />
+          </button>
+
+          <img
+            src={images[currentIndex]}
+            alt={`미리보기 이미지 ${currentIndex + 1}`}
+            className="max-w-full max-h-full object-contain rounded-xl"
+          />
+
+          <button
+            onClick={showNextImage}
+            className="absolute right-2 top-1/2 transform -translate-y-1/2 rounded-full hover:opacity-50"
+          >
+            <ChevronRight className="size-8 text-white/80" />
+          </button>
+        </div>
+
+        {isAdmin && (
+          <footer className="absolute bottom-0 left-0 right-0 flex-center w-full gap-4 text-white/80 p-4">
+            <button
+              className="flex-1 py-3 text-xs rounded-xl  hover:bg-white/10 font-medium"
+              onClick={() => {}}
+              aria-label="이미지 삭제"
+            >
+              삭제
+            </button>
+            <button
+              className="flex-1 py-3 text-xs rounded-xl hover:bg-white/10 font-medium"
+              onClick={downloadCurrentImage}
+              aria-label="이미지 다운로드"
+            >
+              다운로드
+            </button>
+          </footer>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default PhotoTalkGalleryModal;

--- a/src/pages/RsvpStatsPage.tsx
+++ b/src/pages/RsvpStatsPage.tsx
@@ -21,7 +21,6 @@ interface StatsResponse {
 }
 
 const RsvpStatsPage = () => {
-
   const { data: stats } = useGetStats() as { data: StatsResponse | undefined };
 
   // useGetAttendances의 반환 타입을 명확하게 지정
@@ -75,16 +74,14 @@ const RsvpStatsPage = () => {
     //   customFooter={null}
     // >
     <main>
-
       <section className="mb-5 mx-3">
-        <h6 className="flex items-center gap-2 text-xs font-medium text-[#535353] my-4" onClick={() => downloadRsvpExcel(attendanceList)}>
+        <h6 className="flex items-center gap-2 text-xs font-medium text-[#535353] my-4">
           {/* 아이콘 */}
           <img src={statsIcon} alt="stats" />
           <span>하객 분류</span>
         </h6>
 
         <article className="h-fit bg-white rounded-xl w-full p-4">
-
           <RsvpItem title={'총 응답 수'} attend={totalResponses} total={true} />
           <div className="grid grid-cols-2">
             <RsvpItem title={'참석 가능'} attend={totalAttending} />
@@ -111,20 +108,24 @@ const RsvpStatsPage = () => {
           </div>
         </article>
       </section>
-          
+
       <section className="flex-1 mx-3">
-        <div className='flex justify-between'>
+        <div className="flex justify-between">
           <h6 className="flex items-center gap-2 text-xs font-medium text-[#535353]">
             <img src={listIcon} alt="stats" />
             <span>상세 목록</span>
           </h6>
-          <button className='border border-gray-300 rounded-xl my-4 px-2 hover:opacity-80 transition'>
-            <img src="/src/assets/microsoft-excel-128.png" alt="엑셀 파일 다운로드" className="w-8 h-8" />
+          <button className="border border-gray-300 rounded-xl my-4 px-2 hover:opacity-80 transition">
+            <img
+              src="/src/assets/microsoft-excel-128.png"
+              alt="엑셀 파일 다운로드"
+              className="w-8 h-8"
+              onClick={() => downloadRsvpExcel(attendanceList)}
+            />
           </button>
         </div>
 
         <article className="flex flex-col">
-
           {/* 테이블 헤더 */}
           <header className="grid grid-cols-[2.5fr_2.2fr_0.7fr_0.7fr] bg-gray-100 text-sm font-medium text-center py-2 rounded-t-lg border border-gray-300">
             <span>이름</span>

--- a/src/types/invitationType.d.ts
+++ b/src/types/invitationType.d.ts
@@ -29,7 +29,7 @@ export interface InvitationDetiail {
   attendanceIsDining: boolean;
   attendance: boolean;
   font: string;
-  calendars: CalaendarDetail[];
+  calendars: CalendarDetail[];
   maps: MapDetail[];
   galleries: Omit<GalleryDetail[], 'images'>;
   accounts: AccountDetail[];
@@ -38,7 +38,7 @@ export interface InvitationDetiail {
   audio: number | nulll;
 }
 
-interface CalaendarDetail {
+interface CalendarDetail {
   order?: number;
   isActive: boolean;
   calendar: boolean;

--- a/src/utils/downloadUtils.ts
+++ b/src/utils/downloadUtils.ts
@@ -1,0 +1,51 @@
+import JSZip from 'jszip';
+import { saveAs } from 'file-saver';
+
+const fileName = (index: number) => `phototalk_${index + 1}.jpg`;
+const delay = (ms: number) => new Promise((res) => setTimeout(res, ms));
+
+// 한 장 다운로드
+export const downloadImage = (url: string, index: number) => {
+  const link = document.createElement('a');
+
+  link.href = url;
+  link.download = fileName(index);
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+};
+
+// 여러 장 다운로드
+export const downloadSelectedImages = async (selectedImages: string[]) => {
+  // 10개 이상이면 zip 다운
+  if (selectedImages.length >= 10) {
+    const zip = new JSZip();
+    const folder = zip.folder('phototalk-images');
+
+    await Promise.all(
+      selectedImages.map(async (url, index) => {
+        const response = await fetch(url);
+        const blob = await response.blob();
+
+        folder?.file(fileName(index), blob);
+      }),
+    );
+
+    const content = await zip.generateAsync({ type: 'blob' });
+    saveAs(content, 'phototalk_images.zip');
+  } else {
+    // 10개 미만이면 순차 다운
+    for (let index = 0; index < selectedImages.length; index++) {
+      const url = selectedImages[index];
+      const link = document.createElement('a');
+
+      link.href = url;
+      link.download = fileName(index);
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+
+      await delay(500);
+    }
+  }
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈 (선택)

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

- [x] 10장 이상 다운로드 할 경우, zip 압축 파일로 다운 (JSZip 라이브러리)
- [x] 10장 미만은 순차적으로 다운
- [x] 파일명 `phototalk_${index}`로 설정
- [x] 갤러리 모달 `esc` 키보드로 닫기 가능
- [x] 사진 모두 선택하기 버튼 추가
- [x] 엑셀 다운로드 onClick 위치가 잘못되어 있어서 수정


<img width="500" alt="스크린샷 2025-03-31 오전 12 56 22" src="https://github.com/user-attachments/assets/c768ee25-dbca-4675-ab97-c2491cde99c5" />

<img width="600" alt="스크린샷 2025-03-30 오후 6 48 37" src="https://github.com/user-attachments/assets/91d222de-3c25-4f25-a055-9488d2cab4b1" />


## 💬 리뷰 요구사항(선택)

### [MDN 접근성](https://developer.mozilla.org/en-US/docs/Web/Accessibility)

웹 접근성 개선을 위해 `aria-labelledby`, `aria-label`, `role`, img의 `alt` 등을 적용했습니다.
포토톡의 경우, 접근성을 93까지 높일 수 있었는데 앞으로도 조금씩 적용하면 좋을 것 같습니다.

<img width="443" alt="스크린샷 2025-03-30 오후 5 11 00" src="https://github.com/user-attachments/assets/97b68147-1050-43e1-96f9-6e70afb6a17d" />

