### PR TITLE
[Feat] user api: 중복 이메일 계정 구분 로직 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,9 +21,21 @@ import PreviewInvitationPage from '@/pages/PreviewInvitationPage';
 import EditInvitationPage from '@/pages/EditInvitationPage';
 import ResultPage from '@/pages/ResultPage';
 import GuestPhotoTalkPage from '@/pages/PhotoTalk/GuestPhotoTalkPage';
+import { useUserStore } from './store/useUserStore';
+import useAuthStore from './store/useAuthStore';
+import { useEffect } from 'react';
 
 function App() {
   const queryClient = new QueryClient();
+
+  const fetchUserInfo = useUserStore((state) => state.fetchUserInfo);
+  const token = useAuthStore((state) => state.accessToken);
+
+  useEffect(() => {
+    if (token) {
+      fetchUserInfo();
+    }
+  }, [token]);
 
   return (
     <DarkModeProvider>

--- a/src/components/EditMyPage/LogoutModal.tsx
+++ b/src/components/EditMyPage/LogoutModal.tsx
@@ -1,21 +1,21 @@
-import ReusableModal from "../common/Modal/ReusableModal";
+import ReusableModal from '../common/Modal/ReusableModal';
 
 interface LogoutModalProps {
-    isOpen: boolean;
-    onConfirm: () => void;
-    onCancel: () => void;
+  isOpen: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
 }
 
 const LogoutModal = ({ isOpen, onConfirm, onCancel }: LogoutModalProps) => {
-    return (
-        <ReusableModal
-            isOpen={isOpen}
-            title="로그아웃 하시겠습니까?"
-            confirmText="확인"
-            onConfirm={onConfirm}
-            onCancel={onCancel}
-        />
-    );
+  return (
+    <ReusableModal
+      isOpen={isOpen}
+      title="로그아웃 하시겠습니까?"
+      confirmText="확인"
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+    />
+  );
 };
 
 export default LogoutModal;

--- a/src/components/EditMyPage/WithdrawModal.tsx
+++ b/src/components/EditMyPage/WithdrawModal.tsx
@@ -1,21 +1,21 @@
-import ReusableModal from "../common/Modal/ReusableModal";
+import ReusableModal from '../common/Modal/ReusableModal';
 
 interface WithdrawModalProps {
-    isOpen: boolean;
-    onConfirm: () => void;
-    onCancel: () => void;
+  isOpen: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
 }
 
 const WithdrawModal = ({ isOpen, onConfirm, onCancel }: WithdrawModalProps) => {
-    return (
-        <ReusableModal
-            isOpen={isOpen}
-            title="회원탈퇴 하시겠습니까?"
-            confirmText="확인"
-            onConfirm={onConfirm}
-            onCancel={onCancel}
-        />
-    );
+  return (
+    <ReusableModal
+      isOpen={isOpen}
+      title="회원탈퇴 하시겠습니까?"
+      confirmText="확인"
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+    />
+  );
 };
 
 export default WithdrawModal;

--- a/src/components/ResetPassword/ResetPasswordForm.tsx
+++ b/src/components/ResetPassword/ResetPasswordForm.tsx
@@ -1,56 +1,62 @@
-import { useState } from "react";
-import { validateEmail } from "@/utils/validator";
-import { resetPassword } from "@/services/userService";
-import ResetPasswordButton from "./ResetPasswordButton";
+import { useState } from 'react';
+import { validateEmail } from '@/utils/validator';
+import { resetPassword } from '@/services/userService';
+import ResetPasswordButton from './ResetPasswordButton';
 
 interface EmailInfo {
-    email: string;
+  email: string;
 }
 
 interface ResetPasswordFormProps {
-    setIsModalOpen: (value: boolean) => void;
+  setIsModalOpen: (value: boolean) => void;
 }
 
 const ResetPasswordForm = ({ setIsModalOpen }: ResetPasswordFormProps) => {
-    const [emailInfo, setEmailInfo] = useState<EmailInfo>({ email: '' });
-    const [isEmailValid, setIsEmailValid] = useState(false);
+  const [emailInfo, setEmailInfo] = useState<EmailInfo>({ email: '' });
+  const [isEmailValid, setIsEmailValid] = useState(false);
 
-    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const { name, value } = e.target;
-        if (name === "email") {
-            setIsEmailValid(validateEmail(value));
-        }
-        setEmailInfo((prev) => ({ ...prev, [name]: value }));
-    };
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    if (name === 'email') {
+      setIsEmailValid(validateEmail(value));
+    }
+    setEmailInfo((prev) => ({ ...prev, [name]: value }));
+  };
 
-    const handleResetPassword = async () => {
-        try {
-            await resetPassword(emailInfo);
-            setIsModalOpen(true);
-        } catch (error) {
-            console.log('비밀번호 초기화 실패', error);
-        }
-    };
+  const handleResetPassword = async () => {
+    try {
+      await resetPassword(emailInfo);
+      setIsModalOpen(true);
+    } catch (error) {
+      console.log('비밀번호 초기화 실패', error);
+    }
+  };
 
-    return (
-        <div className="flex flex-col w-full gap-3">
-            <h1 className="text-2xl font-semibold pb-6">
-                회원가입 시 등록한<br /> 이메일 주소를 입력해 주세요
-            </h1>
-            <h3 className='text-gray-600 text-sm'>이메일</h3>
-            <input
-                name="email"
-                onChange={handleChange}
-                className="splash-input"
-                type="email"
-                placeholder="이메일 입력"
-            />
-            {!isEmailValid && emailInfo.email.length > 0 && (
-                <p className="text-xs text-rose-500">올바른 이메일 형식을 입력하세요.</p>
-            )}
-            <ResetPasswordButton isEmailValid={isEmailValid} onClick={handleResetPassword} />
-        </div>
-    );
+  return (
+    <div className="flex flex-col w-full gap-3">
+      <h1 className="text-2xl font-semibold pb-6">
+        회원가입 시 등록한
+        <br /> 이메일 주소를 입력해 주세요
+      </h1>
+      <h3 className="text-gray-600 text-sm">이메일</h3>
+      <input
+        name="email"
+        onChange={handleChange}
+        className="splash-input"
+        type="email"
+        placeholder="이메일 입력"
+      />
+      {!isEmailValid && emailInfo.email.length > 0 && (
+        <p className="text-xs text-rose-500">
+          올바른 이메일 형식을 입력하세요.
+        </p>
+      )}
+      <ResetPasswordButton
+        isEmailValid={isEmailValid}
+        onClick={handleResetPassword}
+      />
+    </div>
+  );
 };
 
 export default ResetPasswordForm;

--- a/src/components/ResetPassword/TemporaryPasswordModal.tsx
+++ b/src/components/ResetPassword/TemporaryPasswordModal.tsx
@@ -1,31 +1,30 @@
 interface ModalProps {
-    isOpen: boolean;
-    onConfirm: () => void;
+  isOpen: boolean;
+  onConfirm: () => void;
 }
 
 const TemporaryPassword = ({ isOpen, onConfirm }: ModalProps) => {
-    if (!isOpen) return null;
+  if (!isOpen) return null;
 
-    return (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
-            <div className="relative bg-white rounded-lg shadow-lg w-80">
-
-                <div className="pt-12 pb-8 text-center text-base leading-relaxed">
-                    <p>입력한 주소로<br />임시 비밀번호가 전송되었습니다.</p>
-                </div>
-
-                <div className="flex border-t border-gray-300">
-                    <button
-                        className="w-full py-3 text-red-500"
-                        onClick={onConfirm}
-                    >
-                        확인
-                    </button>
-
-                </div>
-            </div>
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="relative bg-white rounded-lg shadow-lg w-80">
+        <div className="pt-12 pb-8 text-center text-base leading-relaxed">
+          <p>
+            입력한 주소로
+            <br />
+            임시 비밀번호가 전송되었습니다.
+          </p>
         </div>
-    );
+
+        <div className="flex border-t border-gray-300">
+          <button className="w-full py-3 text-red-500" onClick={onConfirm}>
+            확인
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default TemporaryPassword;

--- a/src/components/Signup.tsx
+++ b/src/components/Signup.tsx
@@ -6,6 +6,7 @@ import {
 } from '@/utils/validator';
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router';
+import axios from 'axios';
 
 interface SignupInfo {
   name: string;
@@ -66,7 +67,16 @@ const Signup = () => {
       console.log(responseData);
       navigate('/login');
     } catch (error) {
-      console.log('회원가입 실패', error);
+      if (axios.isAxiosError(error)) {
+        const errMsg = error.response?.data?.message;
+        if (errMsg === '이미 해당 email로 회원가입된 이력있음.') {
+          navigate('/login', {
+            state: { errorMessage: errMsg },
+          });
+        } else {
+          console.error('회원가입 실패', error);
+        }
+      }
     }
   };
 

--- a/src/components/common/AttendanceItem/AttendanceItem.tsx
+++ b/src/components/common/AttendanceItem/AttendanceItem.tsx
@@ -1,4 +1,4 @@
-import { GuestInfo } from "@/types/GuestType";
+import { GuestInfo } from '@/types/GuestType';
 
 interface AttendanceProps {
   guestInfo: GuestInfo;
@@ -6,10 +6,17 @@ interface AttendanceProps {
 
 const AttendanceItem = ({ guestInfo }: AttendanceProps) => {
   const attendanceStatus = guestInfo.attendance ? 'O' : 'X';
-  const diningStatus = guestInfo.isDining === '예정' ? 'O' : guestInfo.isDining === '미정' ? '-' : 'X';
+  const diningStatus =
+    guestInfo.isDining === '예정'
+      ? 'O'
+      : guestInfo.isDining === '미정'
+        ? '-'
+        : 'X';
   return (
     <div className="flex flex-row justify-around gap-1 bg-white p-3 rounded-xl border-2 border-solid border-gray-500">
-      <div className="">{guestInfo.name}님 외 {guestInfo.companions}명</div>
+      <div className="">
+        {guestInfo.name}님 외 {guestInfo.companions}명
+      </div>
       <div>{guestInfo.contact}</div>
       <div>{attendanceStatus}</div>
       <div>{diningStatus}</div>

--- a/src/components/common/Modal/SimpleModal.tsx
+++ b/src/components/common/Modal/SimpleModal.tsx
@@ -1,20 +1,17 @@
 interface ModalProps {
   isOpen: boolean;
+  message: string | React.ReactNode;
   onConfirm: () => void;
 }
 
-const NameInputModal = ({ isOpen, onConfirm }: ModalProps) => {
+const SimpleModal = ({ isOpen, message, onConfirm }: ModalProps) => {
   if (!isOpen) return null;
 
   return (
     <div className="font-Paperlogy fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
       <div className="relative bg-white rounded-lg shadow-lg w-80">
-        <div className="pt-12 pb-8 text-center text-base">
-          <p>
-            신랑 및 신부의 이름을
-            <br />
-            모두 입력해주세요.
-          </p>
+        <div className="flex items-center justify-center pt-4 text-center text-base h-[132px]">
+          <p>{message}</p>
         </div>
 
         <div className="flex border-t border-gray-300">
@@ -27,4 +24,4 @@ const NameInputModal = ({ isOpen, onConfirm }: ModalProps) => {
   );
 };
 
-export default NameInputModal;
+export default SimpleModal;

--- a/src/components/common/RsvpItem/RsvpItem.tsx
+++ b/src/components/common/RsvpItem/RsvpItem.tsx
@@ -20,7 +20,7 @@ export default function RsvpItem({
       <div className={`flex flex-col items-start text-sm ${total && ''}`}>
         {title}
         {description && (
-          <div className="text-[10px] mt-1 text-gray-300">{description}</div>
+          <div className="text-[10px] mt-1 text-gray-400">{description}</div>
         )}
       </div>
       <div

--- a/src/components/common/ToastPopup.tsx
+++ b/src/components/common/ToastPopup.tsx
@@ -1,28 +1,29 @@
-import { useEffect } from "react";
+import { useEffect } from 'react';
 
 export default function ToastPopup({
-    message,
-    setToast,
-    position,
+  message,
+  setToast,
+  position,
 }: {
-    message: string;
-    setToast: React.Dispatch<React.SetStateAction<boolean>>;
-    position: 'top' | 'bottom';
+  message: string;
+  setToast: React.Dispatch<React.SetStateAction<boolean>>;
+  position: 'top' | 'bottom';
 }) {
-    useEffect(() => {
-        const timer = setTimeout(() => {
-            setToast(false);
-        }, 3000);
-        return () => {
-            clearTimeout(timer);
-        };
-    }, [setToast]);
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setToast(false);
+    }, 3000);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [setToast]);
 
-    return (
-        <div
-            className={`z-40 fixed left-1/2 transform -translate-x-1/2 rounded-lg bg-button text-sm p-2 w-1/4
-            ${position === 'top' ? 'top-12' : 'bottom-16'}`}>
-            < p className="text-white text-center">{message}</p>
-        </div >
-    );
+  return (
+    <div
+      className={`z-40 fixed left-1/2 transform -translate-x-1/2 rounded-lg bg-button text-sm p-2 w-1/4
+            ${position === 'top' ? 'top-12' : 'bottom-16'}`}
+    >
+      <p className="text-white text-center">{message}</p>
+    </div>
+  );
 }

--- a/src/components/common/Toggle/OnOff.tsx
+++ b/src/components/common/Toggle/OnOff.tsx
@@ -1,4 +1,3 @@
-
 interface Props {
   state: boolean;
   setState: (enabled: boolean) => void;

--- a/src/components/display/AccountSection/AccountSection.tsx
+++ b/src/components/display/AccountSection/AccountSection.tsx
@@ -55,21 +55,24 @@ const AccountSection = () => {
               {!allEmpty && (
                 <>
                   <div
-                    className={`flex py-3 px-5  cursor-default justify-between items-center  ${value.role === '신랑' ? 'bg-sky-50 bg-opacity-70' : 'bg-pink-50 bg-opacity-70'} rounded-md ${isOpen && 'rounded-b-none'
-                      }`}
+                    className={`flex py-3 px-5  cursor-default justify-between items-center  ${value.role === '신랑' ? 'bg-sky-50 bg-opacity-70' : 'bg-pink-50 bg-opacity-70'} rounded-md ${
+                      isOpen && 'rounded-b-none'
+                    }`}
                     onClick={() =>
                       toggleAccordion(value.role === '신랑' ? 'groom' : 'bride')
                     }
                   >
                     <div className="font-medium">{`${value.role}측에게`}</div>
                     <i
-                      className={`bx bx-chevron-down text-lg transition-all duration-300 ${isOpen ? 'rotate-180' : ''
-                        }`}
+                      className={`bx bx-chevron-down text-lg transition-all duration-300 ${
+                        isOpen ? 'rotate-180' : ''
+                      }`}
                     ></i>
                   </div>
                   <div
-                    className={`overflow-hidden transition-all shadow-inner bg-white ${isOpen ? 'h-fit' : 'h-0'
-                      }`}
+                    className={`overflow-hidden transition-all shadow-inner bg-white ${
+                      isOpen ? 'h-fit' : 'h-0'
+                    }`}
                   >
                     {!accountEmpty && (
                       <AccountNumberItem

--- a/src/components/display/GreetingSection/GreetingSection.tsx
+++ b/src/components/display/GreetingSection/GreetingSection.tsx
@@ -20,4 +20,4 @@ const GreetingSection = () => {
   );
 };
 
-export default GreetingSection
+export default GreetingSection;

--- a/src/components/display/LocationSection/Map.tsx
+++ b/src/components/display/LocationSection/Map.tsx
@@ -42,9 +42,9 @@ const Map = () => {
     if (zoomControl) {
       return subFeatures.canMoveMap
         ? map.addControl(
-          zoomControl,
-          window.kakao.maps.ControlPosition.TOPRIGHT,
-        )
+            zoomControl,
+            window.kakao.maps.ControlPosition.TOPRIGHT,
+          )
         : map.removeControl(zoomControl);
     }
   }, [map, subFeatures.canMoveMap, zoomControl]);

--- a/src/components/display/MusicSection/MusicSection.tsx
+++ b/src/components/display/MusicSection/MusicSection.tsx
@@ -39,7 +39,7 @@ const MusicSection = () => {
   return (
     isMusicFeatureActive && (
       <div className="absolute top-3 right-6 transition-all duration-300">
-        <PlayButton isPlaying={false} onPlayPause={() => { }} />
+        <PlayButton isPlaying={false} onPlayPause={() => {}} />
       </div>
     )
   );

--- a/src/components/form/BasicInformation/NameInput/NameInputModal.tsx
+++ b/src/components/form/BasicInformation/NameInput/NameInputModal.tsx
@@ -1,31 +1,30 @@
 interface ModalProps {
-    isOpen: boolean;
-    onConfirm: () => void;
+  isOpen: boolean;
+  onConfirm: () => void;
 }
 
 const NameInputModal = ({ isOpen, onConfirm }: ModalProps) => {
-    if (!isOpen) return null;
+  if (!isOpen) return null;
 
-    return (
-        <div className="font-Paperlogy fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
-            <div className="relative bg-white rounded-lg shadow-lg w-80">
-
-                <div className="pt-12 pb-8 text-center text-base">
-                    <p>신랑 및 신부의 이름을<br />모두 입력해주세요.</p>
-                </div>
-
-                <div className="flex border-t border-gray-300">
-                    <button
-                        className="w-full py-3 text-red-500"
-                        onClick={onConfirm}
-                    >
-                        확인
-                    </button>
-
-                </div>
-            </div>
+  return (
+    <div className="font-Paperlogy fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="relative bg-white rounded-lg shadow-lg w-80">
+        <div className="pt-12 pb-8 text-center text-base">
+          <p>
+            신랑 및 신부의 이름을
+            <br />
+            모두 입력해주세요.
+          </p>
         </div>
-    );
+
+        <div className="flex border-t border-gray-300">
+          <button className="w-full py-3 text-red-500" onClick={onConfirm}>
+            확인
+          </button>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default NameInputModal;

--- a/src/components/form/Feature/CalendarFeature/CalendarFeature.tsx
+++ b/src/components/form/Feature/CalendarFeature/CalendarFeature.tsx
@@ -16,13 +16,17 @@ const CalendarFeature = () => {
       <div className="flex-center gap-2 text-gray-400 text-[10px] my-6">
         <button
           className={`select-btn ${subCalendarFeatures.calendar ? 'active-btn' : ''}`}
-          onClick={() => toggleSubFeature('calendar', !subCalendarFeatures.calendar)}
+          onClick={() =>
+            toggleSubFeature('calendar', !subCalendarFeatures.calendar)
+          }
         >
           캘린더
         </button>
         <button
           className={`select-btn ${subCalendarFeatures.countdown ? 'active-btn' : ''}`}
-          onClick={() => toggleSubFeature('countdown', !subCalendarFeatures.countdown)}
+          onClick={() =>
+            toggleSubFeature('countdown', !subCalendarFeatures.countdown)
+          }
         >
           카운트다운
         </button>

--- a/src/components/form/Feature/GalleryFeature/GalleryFeature.tsx
+++ b/src/components/form/Feature/GalleryFeature/GalleryFeature.tsx
@@ -7,7 +7,6 @@ import InformationItem from '@/components/common/CreateInvitation/InformationIte
 import useGalleryStore from '@/store/OptionalFeature/useGalleryFeatureStore';
 
 export default function GalleryFeature() {
-
   const fileRef = useRef<HTMLInputElement>(null);
   const {
     galleryImages,

--- a/src/components/form/Feature/GreetingFeature/GreetingFeature.tsx
+++ b/src/components/form/Feature/GreetingFeature/GreetingFeature.tsx
@@ -4,7 +4,12 @@ import useGreetingStore from '../../../../store/useGreetingStore';
 import InformationItem from '@/components/common/CreateInvitation/InformationItem';
 
 const GreetingFeature = () => {
-  const { greetingTitle, greetingContent, setGreetingTitle, setGreetingContent } = useGreetingStore();
+  const {
+    greetingTitle,
+    greetingContent,
+    setGreetingTitle,
+    setGreetingContent,
+  } = useGreetingStore();
   const [isModalOpen, setModalOpen] = useState(false);
 
   return (
@@ -35,9 +40,7 @@ const GreetingFeature = () => {
         <textarea
           placeholder="인사말"
           value={greetingContent}
-          onChange={(e) =>
-            setGreetingContent(e.target.value)
-          }
+          onChange={(e) => setGreetingContent(e.target.value)}
           rows={8}
           className="formInput"
         />

--- a/src/components/form/Feature/NoticeFeature/NoticeItem.tsx
+++ b/src/components/form/Feature/NoticeFeature/NoticeItem.tsx
@@ -27,8 +27,9 @@ const NoticeItem = ({ item, isExpanded, onToggleExpand }: NoticeItemProps) => (
       <div className="flex justify-between items-center mx-3">
         <span className="text-xs font-medium">{item.title}</span>
         <i
-          className={`bx bx-chevron-down transition-transform duration-300 text-lg ${isExpanded ? 'rotate-180' : ''
-            }`}
+          className={`bx bx-chevron-down transition-transform duration-300 text-lg ${
+            isExpanded ? 'rotate-180' : ''
+          }`}
         ></i>
       </div>
 

--- a/src/components/form/Feature/RsvpFeature/RsvpExample.tsx
+++ b/src/components/form/Feature/RsvpFeature/RsvpExample.tsx
@@ -2,7 +2,6 @@ import InformationItem from '@/components/common/CreateInvitation/InformationIte
 import useRSVPStore from '@/store/useRSVPStore';
 
 const RsvpExample = () => {
-
   const { rsvpTitle, rsvpDescription, setRSVPonChange } = useRSVPStore();
 
   return (

--- a/src/components/form/Feature/ThumbnailFeature/ThumbnailFeature.tsx
+++ b/src/components/form/Feature/ThumbnailFeature/ThumbnailFeature.tsx
@@ -3,14 +3,24 @@ import ImageUploader from '@/components/common/ImageUploader';
 import useImageStore from '@/store/useImageStore';
 
 const ThumbnailFeature = () => {
-  const { uploadedImageFile, setUploadedImageFile, uploadedImageUrl, setUploadedImageUrl } = useImageStore();
+  const {
+    uploadedImageFile,
+    setUploadedImageFile,
+    uploadedImageUrl,
+    setUploadedImageUrl,
+  } = useImageStore();
 
   return (
     <div className="mx-4 my-6">
       <InformationItem messages={['썸네일에 나타나는 사진입니다.']} />
       <hr />
       <div className="my-10">
-        <ImageUploader ImageUrl={uploadedImageUrl} ImageFile={uploadedImageFile} setImageUrl={setUploadedImageUrl} setImageFile={setUploadedImageFile} />
+        <ImageUploader
+          ImageUrl={uploadedImageUrl}
+          ImageFile={uploadedImageFile}
+          setImageUrl={setUploadedImageUrl}
+          setImageFile={setUploadedImageFile}
+        />
       </div>
     </div>
   );

--- a/src/components/login/EmailLogin/EmailLoginButton.tsx
+++ b/src/components/login/EmailLogin/EmailLoginButton.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from 'react-router';
 import LoginButton from '../LoginButton';
-import emailLoginImg from '@assets/email-login.png'
+import emailLoginImg from '@assets/email-login.png';
 const EmailLoginButton = () => {
   const navigate = useNavigate();
 

--- a/src/components/login/Login.tsx
+++ b/src/components/login/Login.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router';
 import KakaoLoginButton from './SocialLogin/KakaoLoginButton';
 import NaverLoginButton from './SocialLogin/NaverLoginButton';
 import EmailLoginButton from './EmailLogin/EmailLoginButton';
-import logo from '@/assets/logo2.png'
+import logo from '@/assets/logo2.png';
 const Login = () => {
   return (
     <div className="flex flex-col items-center justify-center w-full h-content">

--- a/src/components/login/SocialLogin/KakaoRedirect.tsx
+++ b/src/components/login/SocialLogin/KakaoRedirect.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router';
 import { postKakaoLogin } from '../../../services/userService';
 import { useUserStore } from '@/store/useUserStore';
+import axios from 'axios';
 
 export const KakaoRedirect = () => {
   const navigate = useNavigate();
@@ -16,12 +17,21 @@ export const KakaoRedirect = () => {
           await fetchUserInfo();
           navigate('/dashboard');
         } catch (error) {
-          console.error('카카오 로그인 실패', error);
+          if (axios.isAxiosError(error)) {
+            const errMsg = error.response?.data?.message;
+            if (errMsg === '이미 해당 email로 회원가입된 이력있음.') {
+              navigate('/login', {
+                state: { errorMessage: errMsg },
+              });
+            } else {
+              console.error('카카오 로그인 실패', error);
+            }
+          }
         }
       }
     };
     handleLogin();
-  }, [navigate]);
+  }, [code, fetchUserInfo, navigate]);
 
   return <div>{/* <h1 className="text-gray-300">로그인 중입니다.</h1> */}</div>;
 };

--- a/src/components/login/SocialLogin/NaverRedirect.tsx
+++ b/src/components/login/SocialLogin/NaverRedirect.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router';
 import { postNaverLogin } from '../../../services/userService';
 import { useUserStore } from '@/store/useUserStore';
+import axios from 'axios';
 
 export const NaverRedirect = () => {
   const navigate = useNavigate();
@@ -16,12 +17,21 @@ export const NaverRedirect = () => {
           await fetchUserInfo();
           navigate('/dashboard');
         } catch (error) {
-          console.error('네이버 로그인 실패', error);
+          if (axios.isAxiosError(error)) {
+            const errMsg = error.response?.data?.message;
+            if (errMsg === '이미 해당 email로 회원가입된 이력있음.') {
+              navigate('/login', {
+                state: { errorMessage: errMsg },
+              });
+            } else {
+              console.error('네이버 로그인 실패', error);
+            }
+          }
         }
       }
     };
     handleLogin();
-  }, [navigate]);
+  }, [code, fetchUserInfo, navigate]);
 
   return <div>{/* <h1 className="text-gray-300">로그인 중입니다.</h1> */}</div>;
 };

--- a/src/hooks/useInvitation.tsx
+++ b/src/hooks/useInvitation.tsx
@@ -26,7 +26,7 @@ export const useGetInvitations = () => {
 };
 
 export const usePostInvitation = () => {
-  const navigate = useNavigate()
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (details: InvitationDetiail) => {
@@ -35,25 +35,26 @@ export const usePostInvitation = () => {
     onSuccess: () => {
       resetAllStores();
       queryClient.invalidateQueries({ queryKey: ['invitations'] });
-      console.log("생성완료")
-      navigate('/dashboard')
+      console.log('생성완료');
+      navigate('/dashboard');
     },
     onError: (err) => {
-      console.log(err)
-    }
+      console.log(err);
+    },
   });
 };
 
 export const useUpdateInvitation = (id: number) => {
-  const navigate = useNavigate()
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (details: InvitationDetiail) => updateInvitation({ id, details }),
+    mutationFn: (details: InvitationDetiail) =>
+      updateInvitation({ id, details }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['invitations'] });
-      navigate('/dashboard')
-      resetAllStores()
-    }
+      navigate('/dashboard');
+      resetAllStores();
+    },
   });
 };
 
@@ -61,10 +62,10 @@ export const useDeleteInvitation = (id: number) => {
   const queryClient = useQueryClient();
   return useMutation({
     onMutate: async (id) => {
-      await queryClient.cancelQueries({ queryKey: ["invitations"] });
-      const previousInvitations = queryClient.getQueryData(["invitations"]);
-      queryClient.setQueryData(["invitations"], (old: InvitationDetiail[]) =>
-        old.filter((inv) => inv.id !== id)
+      await queryClient.cancelQueries({ queryKey: ['invitations'] });
+      const previousInvitations = queryClient.getQueryData(['invitations']);
+      queryClient.setQueryData(['invitations'], (old: InvitationDetiail[]) =>
+        old.filter((inv) => inv.id !== id),
       );
       return { previousInvitations };
     },

--- a/src/hooks/useS3Image.tsx
+++ b/src/hooks/useS3Image.tsx
@@ -1,6 +1,6 @@
-import { getS3ImageUrl, S3Detail } from "@/services/imageService";
-import useImageStore from "@/store/useImageStore";
-import { useMutation } from "@tanstack/react-query";
+import { getS3ImageUrl, S3Detail } from '@/services/imageService';
+import useImageStore from '@/store/useImageStore';
+import { useMutation } from '@tanstack/react-query';
 
 export const useS3Image = () => {
   const { setUploadedImageUrl } = useImageStore();
@@ -10,9 +10,8 @@ export const useS3Image = () => {
       if (data) {
         if (data.imageUrls) {
           if (data.imageUrls.length > 0) {
-            await setUploadedImageUrl(data.imageUrls[0])
-          }
-          else {
+            await setUploadedImageUrl(data.imageUrls[0]);
+          } else {
             console.warn('이미지 URL이 없습니다.');
           }
         }

--- a/src/hooks/useStats.tsx
+++ b/src/hooks/useStats.tsx
@@ -1,23 +1,27 @@
-import { getAttendances, getStats, postAttendance } from "@/services/statsService"
-import { GuestInfo } from "@/types/GuestType";
-import { useMutation, useQuery } from "@tanstack/react-query"
+import {
+  getAttendances,
+  getStats,
+  postAttendance,
+} from '@/services/statsService';
+import { GuestInfo } from '@/types/GuestType';
+import { useMutation, useQuery } from '@tanstack/react-query';
 
 export const useGetStats = () => {
-    return useQuery({
-        queryKey: ['stats'],
-        queryFn: () => getStats(),
-    });
+  return useQuery({
+    queryKey: ['stats'],
+    queryFn: () => getStats(),
+  });
 };
 
 export const useGetAttendances = (page: number, size: number) => {
-    return useQuery({
-        queryKey: ['attendances'],
-        queryFn: () => getAttendances(page, size),
-    });
+  return useQuery({
+    queryKey: ['attendances'],
+    queryFn: () => getAttendances(page, size),
+  });
 };
 
 export const usePostAttendance = (guestInfo: GuestInfo) => {
-    return useMutation({
-        mutationFn: () => postAttendance(guestInfo),
-    });
+  return useMutation({
+    mutationFn: () => postAttendance(guestInfo),
+  });
 };

--- a/src/pages/ChangePasswordPage.tsx
+++ b/src/pages/ChangePasswordPage.tsx
@@ -58,7 +58,7 @@ const ChangePasswordPage = () => {
     try {
       const responseData = await changePassword({ password, newPassword });
       console.log(responseData);
-      navigate('/mypage');
+      navigate('/mypage/rsvp');
     } catch (error) {
       console.log('비밀번호 변경 실패', error);
     }
@@ -69,7 +69,7 @@ const ChangePasswordPage = () => {
   return (
     <PageLayout
       leftButton={
-        <button onClick={() => navigate('/mypage/edit')}>
+        <button onClick={() => navigate(-1)}>
           <BackIcon />
         </button>
       }

--- a/src/pages/CreateInvitationPage.tsx
+++ b/src/pages/CreateInvitationPage.tsx
@@ -13,7 +13,7 @@ import { useInvitationStore } from '@/store/useInvitaionStore';
 import resetAllStores from '@/store/resetStore';
 import useBrideGroomStore from '@/store/useBrideGroomStore';
 import { validateBrideGroomNames } from '@/utils/validator';
-import NameInputModal from '@/components/form/BasicInformation/NameInput/NameInputModal';
+import SimpleModal from '@/components/common/Modal/SimpleModal';
 import ResultDisplay from '@/components/display/ResultDisplay';
 import useImageStore from '@/store/useImageStore';
 import { useS3Image } from '@/hooks/useS3Image';
@@ -177,8 +177,15 @@ const CreateInvitationPage = () => {
           {/* <PreviewDisplay /> */}
         </div>
       </div>
-      <NameInputModal
+      <SimpleModal
         isOpen={isModalOpen}
+        message={
+          <>
+            신랑 및 신부의 이름을
+            <br />
+            모두 입력해주세요.
+          </>
+        }
         onConfirm={() => setIsModalOpen(false)}
       />
     </DndProvider>

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,8 +1,25 @@
 import EmailLogin from '@/components/login/EmailLogin/EmailLogin';
 import SocialLogin from '@/components/login/SocialLogin';
 import Logo from '@/components/common/Logo';
+import SimpleModal from '@/components/common/Modal/SimpleModal';
+import { useLocation } from 'react-router';
+import { useEffect, useState } from 'react';
 
 const LoginPage = () => {
+  const location = useLocation();
+  const errorMessage = location.state?.errorMessage;
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  useEffect(() => {
+    if (errorMessage) {
+      setIsModalOpen(true);
+    }
+  }, [errorMessage]);
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+  };
+
   return (
     <div className="bg-surface dark:bg-surface-dark column-center min-h-screen max-w-[520px] m-auto gap-2">
       <header>
@@ -16,6 +33,12 @@ const LoginPage = () => {
           <SocialLogin />
         </section>
       </main>
+
+      <SimpleModal
+        isOpen={isModalOpen}
+        message="해당 이메일로 가입된 계정이 이미 있습니다."
+        onConfirm={handleCloseModal}
+      />
     </div>
   );
 };

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -47,27 +47,21 @@ const MyPage = () => {
           <DarkModeToggle />
         </button>
 
-        <section className="flex-center text-lg p-6 border-none gap-3">
+        <section className="flex-center text-lg p-10 border-none gap-3">
           <div className="column-center">
             <img
               src={profile}
               alt="profile"
-              className="w-16 block dark:hidden"
+              className="w-12 block dark:hidden"
             />
             <img
               src={profileDark}
               alt="profile"
-              className="w-16 hidden dark:block"
+              className="w-12 hidden dark:block"
             />
-            {/* <button
-              className="text-xs text-[#B4B4B4] font-extralight"
-              onClick={() => navigate('/mypage/edit')}
-            >
-              프로필 수정
-            </button> */}
           </div>
 
-          <div className="flex flex-col text-label dark:text-label-dark text-lg font-extralight leading-6">
+          <div className="flex flex-col text-label dark:text-label-dark text-xl font-extralight leading-6">
             <div>안녕하세요,</div>
             <div className="flex-center">
               <div className="font-medium">{name || '김우결'}</div>

--- a/src/services/imageService.tsx
+++ b/src/services/imageService.tsx
@@ -6,12 +6,10 @@ export interface S3Detail {
 }
 
 export const getS3ImageUrl = async (imageUrl: File[]): Promise<S3Detail> => {
-  const formData = new FormData()
-  imageUrl.map((value) => (
-    formData.append("images", value)
-  ))
+  const formData = new FormData();
+  imageUrl.map((value) => formData.append('images', value));
   if (imageUrl.length == 0) {
-    return { imageUrls: [] }
+    return { imageUrls: [] };
   }
   const response = await axios.post(API.S3Images(), formData, {
     headers: {

--- a/src/services/statsService.ts
+++ b/src/services/statsService.ts
@@ -1,20 +1,23 @@
-import { GuestInfo } from "@/types/GuestType";
-import { API, axiosInstance } from "@/utils/config"
+import { GuestInfo } from '@/types/GuestType';
+import { API, axiosInstance } from '@/utils/config';
 
 // 전체 참석 여부 조회 - 하객 분류
 export const getStats = async () => {
-    const response = await axiosInstance.get(API.ATTENDANCE());
-    return response.data;
-}
+  const response = await axiosInstance.get(API.ATTENDANCE());
+  return response.data;
+};
 
 // 전체 참석 여부 조회 (페이지네이션) - 상세 목록
-export const getAttendances = async (page: number, size: number): Promise<GuestInfo[]> => {
-    const response = await axiosInstance.get(API.ATTENDANCE(page, size));
-    return response.data;
-}
+export const getAttendances = async (
+  page: number,
+  size: number,
+): Promise<GuestInfo[]> => {
+  const response = await axiosInstance.get(API.ATTENDANCE(page, size));
+  return response.data;
+};
 
 // 개인 참석 여부 등록
 export const postAttendance = async (guestInfo: GuestInfo) => {
-    const response = await axiosInstance.post(API.ATTENDANCE(), guestInfo);
-    return response.data;
-}
+  const response = await axiosInstance.post(API.ATTENDANCE(), guestInfo);
+  return response.data;
+};

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -23,10 +23,12 @@ interface PasswordInfo {
 
 export const signup = async (signupInfo: SignupInfo) => {
   console.log({ signupInfo, provider: 'local' });
-  const response = await axiosInstance.post(API.SIGNUP(), { ...signupInfo, provider: 'local' });
+  const response = await axiosInstance.post(API.SIGNUP(), {
+    ...signupInfo,
+    provider: 'local',
+  });
   return response.data;
-}
-
+};
 
 export const postEmailLogin = async (loginInfo: LoginInfo) => {
   const response = await axiosInstance.post(API.EMAILLOGIN(), loginInfo);
@@ -60,14 +62,14 @@ export const withdraw = async () => {
 export const resetPassword = async (emailInfo: EmailInfo) => {
   const response = await axiosInstance.put(API.RESETPASSWORD(), emailInfo);
   return response.data;
-}
+};
 
 export const getUserInfo = async () => {
   const response = await axiosInstance.get(API.ACCOUNT(), {});
   return response.data;
-}
+};
 
 export const changePassword = async (passwordInfo: PasswordInfo) => {
   const response = await axiosInstance.put(API.CHANGEPASSWORD(), passwordInfo);
   return response.data;
-}
+};

--- a/src/store/useUserStore.ts
+++ b/src/store/useUserStore.ts
@@ -2,29 +2,34 @@ import { getUserInfo } from '@/services/userService';
 import { create } from 'zustand';
 
 interface UserState {
-    id: number;
-    email: string | null;
-    name: string | null;
-    provider: string | null;
-    setUser: (id: number, email: string, name: string, provider: string) => void;
-    clearUser: () => void;
-    fetchUserInfo: () => Promise<void>;
+  id: number;
+  email: string | null;
+  name: string | null;
+  provider: string | null;
+  setUser: (id: number, email: string, name: string, provider: string) => void;
+  clearUser: () => void;
+  fetchUserInfo: () => Promise<void>;
 }
 
 export const useUserStore = create<UserState>((set) => ({
-    id: 0,
-    email: null,
-    name: null,
-    provider: null,
+  id: 0,
+  email: null,
+  name: null,
+  provider: null,
 
-    setUser: (id, email, name, provider) => set({ id, email, name, provider }),
-    clearUser: () => set({ id: 0, email: null, name: null, provider: null }),
-    fetchUserInfo: async () => {
-        try {
-            const userInfo = await getUserInfo();
-            set({ id: userInfo.id, email: userInfo.email, name: userInfo.name, provider: userInfo.provider });
-        } catch (error) {
-            console.log('개인 정보 조회 중 오류 발생:', error);
-        }
-    },
+  setUser: (id, email, name, provider) => set({ id, email, name, provider }),
+  clearUser: () => set({ id: 0, email: null, name: null, provider: null }),
+  fetchUserInfo: async () => {
+    try {
+      const userInfo = await getUserInfo();
+      set({
+        id: userInfo.id,
+        email: userInfo.email,
+        name: userInfo.name,
+        provider: userInfo.provider,
+      });
+    } catch (error) {
+      console.log('개인 정보 조회 중 오류 발생:', error);
+    }
+  },
 }));

--- a/src/types/GuestType.d.ts
+++ b/src/types/GuestType.d.ts
@@ -1,12 +1,12 @@
 export interface GuestInfo {
-    id?: number;
-    userId: number;
-    invitationId: number;
-    name: string;
-    contact: string;
-    isDining: '예정' | '안함' | '미정';
-    attendance: boolean;
-    isGroomSide: boolean;
-    isBrideSide: boolean;
-    companions: number;
+  id?: number;
+  userId: number;
+  invitationId: number;
+  name: string;
+  contact: string;
+  isDining: '예정' | '안함' | '미정';
+  attendance: boolean;
+  isGroomSide: boolean;
+  isBrideSide: boolean;
+  companions: number;
 }

--- a/src/utils/excelDownloader.ts
+++ b/src/utils/excelDownloader.ts
@@ -1,66 +1,75 @@
-import { GuestInfo } from "@/types/GuestType";
+import { GuestInfo } from '@/types/GuestType';
 import XLSX from 'xlsx-js-style';
 
 const headerStyle = {
-    font: { bold: true, color: { rgb: '000000' }, name: '함초롱바탕', sz: 13 },
-    fill: { fgColor: { rgb: 'BC8F8F' } },
-    alignment: { horizontal: 'center', vertical: 'center' },
-    border: { left: { style: 'thin', color: { auto: 1 } }, right: { style: 'thin', color: { auto: 1 } }, top: { style: 'thin', color: { auto: 1 } }, bottom: { style: 'thin', color: { auto: 1 } } }
+  font: { bold: true, color: { rgb: '000000' }, name: '함초롱바탕', sz: 13 },
+  fill: { fgColor: { rgb: 'BC8F8F' } },
+  alignment: { horizontal: 'center', vertical: 'center' },
+  border: {
+    left: { style: 'thin', color: { auto: 1 } },
+    right: { style: 'thin', color: { auto: 1 } },
+    top: { style: 'thin', color: { auto: 1 } },
+    bottom: { style: 'thin', color: { auto: 1 } },
+  },
 };
 
 const dataStyle = {
-    font: { color: { rgb: '000000' }, name: '함초롱바탕', sz: 11 },
-    fill: { fgColor: { rgb: 'FFFAFA' } },
-    alignment: { horizontal: 'center', vertical: 'center' },
-    border: { left: { style: 'thin', color: { auto: 1 } }, right: { style: 'thin', color: { auto: 1 } }, top: { style: 'thin', color: { auto: 1 } }, bottom: { style: 'thin', color: { auto: 1 } } }
+  font: { color: { rgb: '000000' }, name: '함초롱바탕', sz: 11 },
+  fill: { fgColor: { rgb: 'FFFAFA' } },
+  alignment: { horizontal: 'center', vertical: 'center' },
+  border: {
+    left: { style: 'thin', color: { auto: 1 } },
+    right: { style: 'thin', color: { auto: 1 } },
+    top: { style: 'thin', color: { auto: 1 } },
+    bottom: { style: 'thin', color: { auto: 1 } },
+  },
 };
 
 export const downloadRsvpExcel = (attendanceList: GuestInfo[]) => {
-    const excelData = attendanceList.map((item) => ({
-        "대표자": item.name,
-        "참석자 수": item.companions + 1,
-        "연락처": item.contact,
-        "참석": item.attendance ? "O" : "X",
-        "식사": item.isDining === "예정" ? "O" : item.isDining === "미정" ? "-" : "X",
-    }));
+  const excelData = attendanceList.map((item) => ({
+    대표자: item.name,
+    '참석자 수': item.companions + 1,
+    연락처: item.contact,
+    참석: item.attendance ? 'O' : 'X',
+    식사: item.isDining === '예정' ? 'O' : item.isDining === '미정' ? '-' : 'X',
+  }));
 
-    // Excel 파일 생성 및 다운로드
-    const wb = XLSX.utils.book_new();
+  // Excel 파일 생성 및 다운로드
+  const wb = XLSX.utils.book_new();
 
-    // 열의 폭을 정의
-    const colWidths = [80, 80, 120, 80, 80];
+  // 열의 폭을 정의
+  const colWidths = [80, 80, 120, 80, 80];
 
-    // cols 속성을 사용하여 각 열의 폭을 조절
-    const cols = colWidths.map(width => ({ wpx: width }));
+  // cols 속성을 사용하여 각 열의 폭을 조절
+  const cols = colWidths.map((width) => ({ wpx: width }));
 
-    const headerRow = [
-        { v: '대표자', t: 's', s: headerStyle },
-        { v: '참석자 수', t: 's', s: headerStyle },
-        { v: '연락처', t: 's', s: headerStyle },
-        { v: '참석', t: 's', s: headerStyle },
-        { v: '식사', t: 's', s: headerStyle },
-    ];
+  const headerRow = [
+    { v: '대표자', t: 's', s: headerStyle },
+    { v: '참석자 수', t: 's', s: headerStyle },
+    { v: '연락처', t: 's', s: headerStyle },
+    { v: '참석', t: 's', s: headerStyle },
+    { v: '식사', t: 's', s: headerStyle },
+  ];
 
-    const dataRows = excelData.map(row => [
-        { v: row["대표자"], t: 's', s: dataStyle },
-        { v: row["참석자 수"], t: 's', s: dataStyle },
-        { v: row["연락처"], t: 's', s: dataStyle },
-        { v: row["참석"], t: 's', s: dataStyle },
-        { v: row["식사"], t: 's', s: dataStyle },
-    ]);
+  const dataRows = excelData.map((row) => [
+    { v: row['대표자'], t: 's', s: dataStyle },
+    { v: row['참석자 수'], t: 's', s: dataStyle },
+    { v: row['연락처'], t: 's', s: dataStyle },
+    { v: row['참석'], t: 's', s: dataStyle },
+    { v: row['식사'], t: 's', s: dataStyle },
+  ]);
 
-    const rows = [headerRow, ...dataRows];
+  const rows = [headerRow, ...dataRows];
 
-    // 새로운 Sheet 객체 생성
-    const ws = XLSX.utils.aoa_to_sheet(rows);
+  // 새로운 Sheet 객체 생성
+  const ws = XLSX.utils.aoa_to_sheet(rows);
 
-    // cols 속성 적용
-    ws['!cols'] = cols;
+  // cols 속성 적용
+  ws['!cols'] = cols;
 
-    // workbook에 추가
-    XLSX.utils.book_append_sheet(wb, ws, '참석자 목록');
+  // workbook에 추가
+  XLSX.utils.book_append_sheet(wb, ws, '참석자 목록');
 
-    // 파일 다운로드
-    XLSX.writeFile(wb, 'rsvp_attendance.xlsx');
-
-}
+  // 파일 다운로드
+  XLSX.writeFile(wb, 'rsvp_attendance.xlsx');
+};

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -8,7 +8,8 @@ export const validateEmail = (email: string): boolean => {
 };
 
 export const validatePassword = (password: string): boolean => {
-  const passwordRegex = /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{8,16}$/;
+  const passwordRegex =
+    /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*])[A-Za-z\d!@#$%^&*]{8,16}$/;
   return passwordRegex.test(password);
 };
 


### PR DESCRIPTION
## 📝 작업 내용
 - 사용자 정보 손실 버그 해결
 - 세부 디자인 일부 수정
 - 하나의 이메일로 계정 1개만 생성되도록 로직 추가(소셜 로그인의 경우 로그인 시, 이메일 로그인의 경우는 회원가입 때 계정 생성 시)
 
<img width="340" alt="image" src="https://github.com/user-attachments/assets/a3d4c58f-4e3a-4ff9-8b57-a265d5972935" />

 - prettier 설정이 이전에 적용되지 않았던  파일 설정시켜서 업데이트

