### PR TITLE
[Feat] 포토톡 무한스크롤 및 전체 조회 api 추가

### DIFF
--- a/src/components/common/PhotoTalk/List/PhotoTalkCommonList.tsx
+++ b/src/components/common/PhotoTalk/List/PhotoTalkCommonList.tsx
@@ -3,7 +3,7 @@ import PhotoTalkGallery from '@/components/common/PhotoTalk/Gallery/PhotoTalkGal
 import { PhotoTalk } from '@/types/phototalkType';
 import { UserMode } from '@/types/users';
 import { examplePhototalkCard } from '@/constants/phototalkData';
-import PhotoTalkEmptyState from '@/components/common/PhotoTalk/EmptyState/PhotoTalkEmptyState';
+// import PhotoTalkEmptyState from '@/components/common/PhotoTalk/EmptyState/PhotoTalkEmptyState';
 import SkeletonPhotoTalk from '../../Skeleton/SkeletonPhotoTalk';
 import SkeletonGallery from '../../Skeleton/SkeletonGallery';
 
@@ -14,6 +14,8 @@ interface PhotoTalkCommonListProps {
   onDelete: (photoTalk: PhotoTalk) => void;
   isGalleryOpen: boolean;
   isPending: boolean;
+  observeRef?: React.RefObject<HTMLDivElement>;
+  isFetchingNextPage?: boolean;
 }
 
 const PhotoTalkCommonList = ({
@@ -23,8 +25,11 @@ const PhotoTalkCommonList = ({
   onDelete,
   isGalleryOpen,
   isPending,
+  observeRef,
+  isFetchingNextPage,
 }: PhotoTalkCommonListProps) => {
-  const isCardEmpty = !isPending && photoTalkList.length === 0;
+  const isCardEmpty =
+    !isPending && !isFetchingNextPage && photoTalkList.length === 0;
   const photoTalks = isCardEmpty ? examplePhototalkCard : photoTalkList;
 
   if (isPending) {
@@ -37,28 +42,42 @@ const PhotoTalkCommonList = ({
         ));
   }
 
+  // if (isCardEmpty) {
+  //   return (
+  //     <PhotoTalkEmptyState
+  //       userMode={userMode}
+  //       viewType={`${isGalleryOpen ? 'gallery' : 'list'}`}
+  //     />
+  //   );
+  // }
+
   return (
     <>
-      {isCardEmpty && (
-        <PhotoTalkEmptyState
-          userMode={userMode}
-          viewType={`${isGalleryOpen ? 'gallery' : 'list'}`}
-        />
-      )}
-
       {isGalleryOpen ? (
         <PhotoTalkGallery userMode={userMode} />
       ) : (
-        photoTalks.map((photoTalk) => (
-          <PhotoTalkCard
-            key={photoTalk.id}
-            photoTalk={photoTalk}
-            isExample={isCardEmpty}
-            onEdit={onEdit ? () => onEdit(photoTalk) : undefined}
-            onDelete={() => onDelete(photoTalk)}
-            userMode={userMode}
-          />
-        ))
+        <>
+          {photoTalks.map((photoTalk) => {
+            const isExampleCard =
+              isCardEmpty &&
+              examplePhototalkCard.some((ex) => ex.id === photoTalk.id);
+
+            return (
+              <PhotoTalkCard
+                key={photoTalk.id}
+                photoTalk={photoTalk}
+                isExample={isExampleCard}
+                onEdit={onEdit ? () => onEdit(photoTalk) : undefined}
+                onDelete={() => onDelete(photoTalk)}
+                userMode={userMode}
+              />
+            );
+          })}
+
+          <div ref={observeRef} className="">
+            {isFetchingNextPage && <SkeletonPhotoTalk />}
+          </div>
+        </>
       )}
     </>
   );

--- a/src/components/common/PhotoTalk/List/PhotoTalkListAdmin.tsx
+++ b/src/components/common/PhotoTalk/List/PhotoTalkListAdmin.tsx
@@ -11,11 +11,15 @@ const userMode = USER_MODE.ADMIN;
 interface PhotoTalkListAdminProps {
   photoTalkList: PhotoTalk[];
   isLoading: boolean;
+  observeRef?: React.RefObject<HTMLDivElement>;
+  isFetchingNextPage?: boolean;
 }
 
 const PhotoTalkListAdmin = ({
   photoTalkList,
   isLoading,
+  observeRef,
+  isFetchingNextPage,
 }: PhotoTalkListAdminProps) => {
   const [isGalleryOpen, setGalleryOpen] = useState(false);
 
@@ -28,7 +32,7 @@ const PhotoTalkListAdmin = ({
     });
 
   return (
-    <div>
+    <>
       <PhotoTalkListHeader
         userMode={userMode}
         isGalleryOpen={isGalleryOpen}
@@ -41,6 +45,8 @@ const PhotoTalkListAdmin = ({
         onDelete={(talk) => openModal(talk, ACTION_MODE.DELETE)}
         isGalleryOpen={isGalleryOpen}
         isPending={isLoading}
+        observeRef={observeRef}
+        isFetchingNextPage={isFetchingNextPage}
       />
 
       <ReusableModal
@@ -50,7 +56,7 @@ const PhotoTalkListAdmin = ({
         title="정말 삭제하시겠습니까?"
         confirmText="삭제"
       />
-    </div>
+    </>
   );
 };
 

--- a/src/components/common/PhotoTalk/List/PhotoTalkListGuest.tsx
+++ b/src/components/common/PhotoTalk/List/PhotoTalkListGuest.tsx
@@ -13,12 +13,16 @@ interface PhotoTalkListGuestProps {
   photoTalkList: PhotoTalk[];
   isLoading: boolean;
   onOpenEditor: () => void;
+  observeRef?: React.RefObject<HTMLDivElement>;
+  isFetchingNextPage?: boolean;
 }
 
 const PhotoTalkListGuest = ({
   photoTalkList,
   isLoading,
   onOpenEditor,
+  observeRef,
+  isFetchingNextPage,
 }: PhotoTalkListGuestProps) => {
   const { setEditingPhotoTalk } = usePhotoTalkStore();
   const [isGalleryOpen, setGalleryOpen] = useState(false);
@@ -58,6 +62,8 @@ const PhotoTalkListGuest = ({
         onDelete={(talk) => openModal(talk, ACTION_MODE.DELETE)}
         isGalleryOpen={isGalleryOpen}
         isPending={isLoading}
+        observeRef={observeRef}
+        isFetchingNextPage={isFetchingNextPage}
       />
 
       <PasswordConfirmModal

--- a/src/components/common/PhotoTalk/List/PhotoTalkListPreview.tsx
+++ b/src/components/common/PhotoTalk/List/PhotoTalkListPreview.tsx
@@ -48,6 +48,7 @@ const PhotoTalkListPreview = ({
         onEdit={() => openModal(ACTION_MODE.EDIT)}
         onDelete={() => openModal(ACTION_MODE.DELETE)}
         isGalleryOpen={isGalleryOpen}
+        isPending={false}
       />
 
       <PasswordConfirmModal

--- a/src/hooks/usePhototalk.tsx
+++ b/src/hooks/usePhototalk.tsx
@@ -9,6 +9,88 @@ import {
 } from '@/services/phototalkService';
 import { PhotoTalk } from '@/types/phototalkType';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface useInfinitePhototalkByQueryProps<T, ItemType> {
+  queryFn: (page: number) => Promise<T>; // 실제 요청 함수
+  extractItems: (response: T) => ItemType[]; /// 실제로 보여줄 데이터 배열만 추출
+  getHasMore: (response: T) => boolean; // 다음 페이지가 존재하는지 여부
+  initialPage?: number; // 처음 시작 페이지 번호
+  enabled?: boolean; // 무한스크롤 활성화 여부
+}
+
+// 포토톡 무한스크롤
+export const useInfinitePhototalkByQuery = <T, ItemType>({
+  queryFn,
+  extractItems,
+  getHasMore,
+  initialPage = 1,
+  enabled = true,
+}: useInfinitePhototalkByQueryProps<T, ItemType>) => {
+  const [page, setPage] = useState(initialPage); // 현재 몇 번째 페이지
+  const [items, setItems] = useState<ItemType[]>([]); // 현재까지 로딩된 모든 포토톡 데이터
+  // const [isLoading, setIsLoading] = useState(false); // 중복 요청 방지
+  const [hasMore, setHasMore] = useState(true); // 다음 페이지가 있는지 여부
+  const [isFetching, setIsFetching] = useState(false);
+  const observeRef = useRef<HTMLDivElement | null>(null); // 무한스크롤 감지 대상
+
+  const isInitialLoading = page === 1 && isFetching;
+  const isFetchingNextPage = page > 1 && isFetching;
+
+  // 다음 페이지 요청 함수
+  const loadMore = useCallback(async () => {
+    if (!enabled || !hasMore || isFetching) return;
+    setIsFetching(true);
+
+    try {
+      const res = await queryFn(page); // 페이지 api 호출
+
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      setItems((prev) => [...prev, ...extractItems(res)]); // 기존 + 새 데이터 누적
+      setHasMore(getHasMore(res)); // 더 불러올 수 있는지
+      setPage((prev) => prev + 1); // 다음 페이지로 증가
+    } catch (e) {
+      console.error(e);
+    } finally {
+      setIsFetching(false);
+    }
+  }, [enabled, hasMore, isFetching, page, queryFn, extractItems, getHasMore]);
+
+  // IntersectionObserver가 호출할 함수
+  const observerCallback = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      if (entries[0].isIntersecting) {
+        console.log('감지됨');
+        loadMore();
+      }
+    },
+    [loadMore],
+  );
+
+  // IntersectionObserver 등록
+  useEffect(() => {
+    const currentRef = observeRef.current;
+    if (!enabled || !currentRef) return;
+
+    const observer = new IntersectionObserver(observerCallback, {
+      threshold: 0.2,
+    });
+
+    observer.observe(currentRef);
+    return () => {
+      if (currentRef) observer.unobserve(currentRef);
+    };
+  }, [observerCallback, enabled]);
+
+  return {
+    items,
+    isLoading: isInitialLoading,
+    isFetchingNextPage,
+    hasMore,
+    observeRef,
+  };
+};
 
 // 포토톡 전체 조회
 export const useGetPhototalks = (page: number, size: number) => {

--- a/src/pages/PhotoTalk/AdminPhotoTalkPage.tsx
+++ b/src/pages/PhotoTalk/AdminPhotoTalkPage.tsx
@@ -1,23 +1,36 @@
 import PhotoTalkListAdmin from '@/components/common/PhotoTalk/List/PhotoTalkListAdmin';
-import { useGetPhototalks } from '@/hooks/usePhototalk';
+import { useInfinitePhototalkByQuery } from '@/hooks/usePhototalk';
+import { getPhototalks } from '@/services/phototalkService';
 import usePhotoTalkStore from '@/store/usePhotoTalkStore';
+import { PhotoTalk, PhotoTalkResponse } from '@/types/phototalkType';
 import { useEffect } from 'react';
 
 const AdminPhotoTalkPage = () => {
-  const { data, isLoading } = useGetPhototalks(1, 20);
+  const {
+    items: data,
+    isLoading,
+    observeRef,
+    isFetchingNextPage,
+  } = useInfinitePhototalkByQuery<PhotoTalkResponse, PhotoTalk>({
+    queryFn: (page) => getPhototalks(page, 6),
+    extractItems: (res) => res.allCelebrationMsgs,
+    getHasMore: (res) => res.currentPage < res.totalPages,
+  });
   const { setPhotoTalkList } = usePhotoTalkStore();
 
   useEffect(() => {
-    if (data) {
-      setPhotoTalkList(data.allCelebrationMsgs);
+    if (data.length > 0) {
+      setPhotoTalkList(data);
     }
-  }, [data]);
+  }, [data, setPhotoTalkList]);
 
   return (
     <main className="min-h-screen" aria-label="관리자 포토톡 리스트">
       <PhotoTalkListAdmin
-        photoTalkList={data?.allCelebrationMsgs || []}
+        photoTalkList={data || []}
         isLoading={isLoading}
+        observeRef={observeRef}
+        isFetchingNextPage={isFetchingNextPage}
       />
     </main>
   );


### PR DESCRIPTION
## #️⃣ 연관된 이슈 (선택)

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

- react-query와 observer intersection api를 사용해서 무한스크롤 구현
- 하객 전체 조회 api 추가 (토큰 x)

<img width="400" alt="스크린샷 2025-05-03 오후 7 49 13" src="https://github.com/user-attachments/assets/edfae2cf-f3d4-4cc1-a89c-eab97fb66954" />


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
